### PR TITLE
add cf.security_groups array property, applied to space creation

### DIFF
--- a/jobs/broker-deploy/spec
+++ b/jobs/broker-deploy/spec
@@ -39,6 +39,11 @@ properties:
     description: Override the default route (cf.appname + shared apps domain)
     example:
     - kafka-broker.system.domain.com
+  cf.security_groups:
+    description: optional security groups to assign to the kafka broker space
+    example:
+    - kafka-cluster-secgroup
+
 
   cf.redis.service_instance_name:
     description: 'Name of redis service instance used by broker'

--- a/jobs/broker-deploy/templates/bin/run
+++ b/jobs/broker-deploy/templates/bin/run
@@ -39,6 +39,12 @@ space_guid=$(cf curl /v2/organizations/$org_guid/spaces\?q=name:$CF_SPACE | jq -
 if [[ "${space_guid}" == "missing" ]]; then
   cf create-space $CF_SPACE
   space_guid=$(cf curl /v2/organizations/$org_guid/spaces\?q=name:$CF_SPACE | jq -r '.resources[0].metadata.guid // ""')
+  
+<% p('cf.security_groups', []).each do |security_group| %>
+  cf bind-security-group  <%= security_group %> $CF_ORG $CF_SPACE
+<% end %>  
+  
+  
 fi
 cf target -o $CF_ORG -s $CF_SPACE
 


### PR DESCRIPTION
this enables kafka broker space creation, in cf secured environment, using predefined cf security groups
