### PR TITLE
Bump memory size to 1GB and make it configurable

### DIFF
--- a/jobs/broker-deploy/spec
+++ b/jobs/broker-deploy/spec
@@ -35,6 +35,9 @@ properties:
   cf.appname:
     description: Name of broker within CF space
     default: starkandwayne-kafka-broker
+  cf.appsize:
+    description: Memory size required for the broker
+    default: 1GB
   cf.routes:
     description: Override the default route (cf.appname + shared apps domain)
     example:

--- a/jobs/broker-deploy/templates/config/manifest.yml
+++ b/jobs/broker-deploy/templates/config/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: <%= p("cf.appname") %>
-  memory: 512M
+  memory: <%= p("cf.appsize") %>
   instances: 1
   path: /var/vcap/packages/kafka-service-broker/target/kafka-broker.jar
   services: [ <%= p("cf.redis.service_instance_name") %> ]


### PR DESCRIPTION
#5 Bumps the default memory size to 1GB to allow broker to start up