### PR TITLE
consume a 'cf-admin-user' link

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-cf-cli/cf-cli_6.25.0_linux_x86-64.tgz:
-  size: 5088758
-  object_id: 25bacd9f-8659-4ae5-7821-71b76c4d84a0
-  sha: 82728ff9fed87554a14a2e5d2b4b743b8f2885ae
+cf-cli/cf-cli_6.32.0_linux_x86-64.tgz:
+  size: 6065317
+  object_id: e8ae0482-bce9-44b6-5bff-d4ed619b4a05
+  sha: ad4dd01db5e6498bd38583d73c75480c700e1b5f
 jq/jq-linux64-1.5:
   size: 3027945
   object_id: 10f187a7-d2ec-49f4-52d3-ada41264adef

--- a/jobs/broker-delete/spec
+++ b/jobs/broker-delete/spec
@@ -5,8 +5,8 @@ templates:
   bin/run: bin/run
 
 consumes:
-- name: cf
-  type: cf
+- name: cf-admin-user
+  type: api-user
   optional: true
 
 properties:

--- a/jobs/broker-delete/spec
+++ b/jobs/broker-delete/spec
@@ -4,6 +4,11 @@ packages: [cf-cli, jq]
 templates:
   bin/run: bin/run
 
+consumes:
+- name: cf
+  type: cf
+  optional: true
+
 properties:
   cf.api_url:
     description: 'Full URL of Cloud Foundry API'

--- a/jobs/broker-delete/templates/bin/run
+++ b/jobs/broker-delete/templates/bin/run
@@ -10,17 +10,11 @@ export PATH=$PATH:/var/vcap/packages/cf-cli/bin
 export CF_HOME=/var/vcap/data/cf_home
 mkdir -p $CF_HOME
 
-<% if_link("cf") do |cf| -%>
-CF_API_URL='<%= cf.p("api_url") %>'
-CF_ADMIN_USERNAME='<%= cf.p("admin_username") %>'
-CF_ADMIN_PASSWORD='<%= cf.p("admin_password") %>'
+<% cf = nil; if_link("cf") { |link| cf = link } -%>
+CF_API_URL='<%= cf ? cf.p("api_url") : p("cf.api_url") %>'
+CF_ADMIN_USERNAME='<%= cf ? cf.p("admin_username") : p("cf.username") %>'
+CF_ADMIN_PASSWORD='<%= cf ? cf.p("admin_password") : p("cf.password") %>'
 CF_SKIP_SSL_VALIDATION=true
-<% end.else do %>
-CF_API_URL='<%= p("cf.api_url") %>'
-CF_ADMIN_USERNAME='<%= p("cf.username") %>'
-CF_ADMIN_PASSWORD='<%= p("cf.password") %>'
-CF_SKIP_SSL_VALIDATION='<%= p("cf.skip_ssl_validation") %>'
-<% end %>
 
 CF_ORG='<%= p("cf.org") %>'
 CF_SPACE='<%= p("cf.space") %>'

--- a/jobs/broker-delete/templates/bin/run
+++ b/jobs/broker-delete/templates/bin/run
@@ -10,10 +10,17 @@ export PATH=$PATH:/var/vcap/packages/cf-cli/bin
 export CF_HOME=/var/vcap/data/cf_home
 mkdir -p $CF_HOME
 
+<% if_link("cf") do |cf| -%>
+CF_API_URL='<%= cf.p("api_url") %>'
+CF_ADMIN_USERNAME='<%= cf.p("admin_username") %>'
+CF_ADMIN_PASSWORD='<%= cf.p("admin_password") %>'
+CF_SKIP_SSL_VALIDATION=true
+<% else.do %>
 CF_API_URL='<%= p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= p("cf.password") %>'
 CF_SKIP_SSL_VALIDATION='<%= p("cf.skip_ssl_validation") %>'
+<% end %>
 
 CF_ORG='<%= p("cf.org") %>'
 CF_SPACE='<%= p("cf.space") %>'

--- a/jobs/broker-delete/templates/bin/run
+++ b/jobs/broker-delete/templates/bin/run
@@ -10,7 +10,7 @@ export PATH=$PATH:/var/vcap/packages/cf-cli/bin
 export CF_HOME=/var/vcap/data/cf_home
 mkdir -p $CF_HOME
 
-<% cf = nil; if_link("cf") { |link| cf = link } -%>
+<% cf = nil; if_link("cf-admin-user") { |link| cf = link } -%>
 CF_API_URL='<%= cf ? cf.p("api_url") : p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= cf ? cf.p("admin_username") : p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= cf ? cf.p("admin_password") : p("cf.password") %>'

--- a/jobs/broker-delete/templates/bin/run
+++ b/jobs/broker-delete/templates/bin/run
@@ -14,7 +14,14 @@ mkdir -p $CF_HOME
 CF_API_URL='<%= cf ? cf.p("api_url") : p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= cf ? cf.p("admin_username") : p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= cf ? cf.p("admin_password") : p("cf.password") %>'
-CF_SKIP_SSL_VALIDATION=true
+<% if cf -%>
+mkdir -p /var/vcap/sys/run
+cat > /var/vcap/sys/run/cf.crt <<EOF
+<%= cf.p("ca_cert") %>
+EOF
+export SSL_CERT_FILE=/var/vcap/sys/run/cf.crt
+<% end -%>
+CF_SKIP_SSL_VALIDATION=<%= p("cf.skip_ssl_validation") %>
 
 CF_ORG='<%= p("cf.org") %>'
 CF_SPACE='<%= p("cf.space") %>'

--- a/jobs/broker-delete/templates/bin/run
+++ b/jobs/broker-delete/templates/bin/run
@@ -15,7 +15,7 @@ CF_API_URL='<%= cf.p("api_url") %>'
 CF_ADMIN_USERNAME='<%= cf.p("admin_username") %>'
 CF_ADMIN_PASSWORD='<%= cf.p("admin_password") %>'
 CF_SKIP_SSL_VALIDATION=true
-<% else.do %>
+<% end.else do %>
 CF_API_URL='<%= p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= p("cf.password") %>'

--- a/jobs/broker-deploy/spec
+++ b/jobs/broker-deploy/spec
@@ -8,8 +8,8 @@ templates:
 consumes:
 - name: zookeeper
   type: zookeeper
-- name: cf
-  type: cf
+- name: cf-admin-user
+  type: api-user
   optional: true
 
 properties:

--- a/jobs/broker-deploy/spec
+++ b/jobs/broker-deploy/spec
@@ -8,6 +8,9 @@ templates:
 consumes:
 - name: zookeeper
   type: zookeeper
+- name: cf
+  type: cf
+  optional: true
 
 properties:
   username:

--- a/jobs/broker-deploy/templates/bin/run
+++ b/jobs/broker-deploy/templates/bin/run
@@ -15,7 +15,14 @@ mkdir -p $CF_HOME
 CF_API_URL='<%= cf ? cf.p("api_url") : p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= cf ? cf.p("admin_username") : p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= cf ? cf.p("admin_password") : p("cf.password") %>'
-CF_SKIP_SSL_VALIDATION=true
+<% if cf -%>
+mkdir -p /var/vcap/sys/run
+cat > /var/vcap/sys/run/cf.crt <<EOF
+<%= cf.p("ca_cert") %>
+EOF
+export SSL_CERT_FILE=/var/vcap/sys/run/cf.crt
+<% end -%>
+CF_SKIP_SSL_VALIDATION=<%= p("cf.skip_ssl_validation") %>
 
 CF_ORG='<%= p("cf.org") %>'
 CF_SPACE='<%= p("cf.space") %>'

--- a/jobs/broker-deploy/templates/bin/run
+++ b/jobs/broker-deploy/templates/bin/run
@@ -11,17 +11,11 @@ export PATH=$PATH:/var/vcap/packages/jq/bin
 export CF_HOME=/var/vcap/data/cf_home
 mkdir -p $CF_HOME
 
-<% if_link("cf") do |cf| -%>
-CF_API_URL='<%= cf.p("api_url") %>'
-CF_ADMIN_USERNAME='<%= cf.p("admin_username") %>'
-CF_ADMIN_PASSWORD='<%= cf.p("admin_password") %>'
+<% cf = nil; if_link("cf") { |link| cf = link } -%>
+CF_API_URL='<%= cf ? cf.p("api_url") : p("cf.api_url") %>'
+CF_ADMIN_USERNAME='<%= cf ? cf.p("admin_username") : p("cf.username") %>'
+CF_ADMIN_PASSWORD='<%= cf ? cf.p("admin_password") : p("cf.password") %>'
 CF_SKIP_SSL_VALIDATION=true
-<% end.else do %>
-CF_API_URL='<%= p("cf.api_url") %>'
-CF_ADMIN_USERNAME='<%= p("cf.username") %>'
-CF_ADMIN_PASSWORD='<%= p("cf.password") %>'
-CF_SKIP_SSL_VALIDATION='<%= p("cf.skip_ssl_validation") %>'
-<% end %>
 
 CF_ORG='<%= p("cf.org") %>'
 CF_SPACE='<%= p("cf.space") %>'

--- a/jobs/broker-deploy/templates/bin/run
+++ b/jobs/broker-deploy/templates/bin/run
@@ -11,10 +11,17 @@ export PATH=$PATH:/var/vcap/packages/jq/bin
 export CF_HOME=/var/vcap/data/cf_home
 mkdir -p $CF_HOME
 
+<% if_link("cf") do |cf| -%>
+CF_API_URL='<%= cf.p("api_url") %>'
+CF_ADMIN_USERNAME='<%= cf.p("admin_username") %>'
+CF_ADMIN_PASSWORD='<%= cf.p("admin_password") %>'
+CF_SKIP_SSL_VALIDATION=true
+<% else.do %>
 CF_API_URL='<%= p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= p("cf.password") %>'
 CF_SKIP_SSL_VALIDATION='<%= p("cf.skip_ssl_validation") %>'
+<% end %>
 
 CF_ORG='<%= p("cf.org") %>'
 CF_SPACE='<%= p("cf.space") %>'
@@ -39,12 +46,12 @@ space_guid=$(cf curl /v2/organizations/$org_guid/spaces\?q=name:$CF_SPACE | jq -
 if [[ "${space_guid}" == "missing" ]]; then
   cf create-space $CF_SPACE
   space_guid=$(cf curl /v2/organizations/$org_guid/spaces\?q=name:$CF_SPACE | jq -r '.resources[0].metadata.guid // ""')
-  
+
 <% p('cf.security_groups', []).each do |security_group| %>
   cf bind-security-group  <%= security_group %> $CF_ORG $CF_SPACE
-<% end %>  
-  
-  
+<% end %>
+
+
 fi
 cf target -o $CF_ORG -s $CF_SPACE
 

--- a/jobs/broker-deploy/templates/bin/run
+++ b/jobs/broker-deploy/templates/bin/run
@@ -11,7 +11,7 @@ export PATH=$PATH:/var/vcap/packages/jq/bin
 export CF_HOME=/var/vcap/data/cf_home
 mkdir -p $CF_HOME
 
-<% cf = nil; if_link("cf") { |link| cf = link } -%>
+<% cf = nil; if_link("cf-admin-user") { |link| cf = link } -%>
 CF_API_URL='<%= cf ? cf.p("api_url") : p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= cf ? cf.p("admin_username") : p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= cf ? cf.p("admin_password") : p("cf.password") %>'

--- a/jobs/broker-deploy/templates/bin/run
+++ b/jobs/broker-deploy/templates/bin/run
@@ -16,7 +16,7 @@ CF_API_URL='<%= cf.p("api_url") %>'
 CF_ADMIN_USERNAME='<%= cf.p("admin_username") %>'
 CF_ADMIN_PASSWORD='<%= cf.p("admin_password") %>'
 CF_SKIP_SSL_VALIDATION=true
-<% else.do %>
+<% end.else do %>
 CF_API_URL='<%= p("cf.api_url") %>'
 CF_ADMIN_USERNAME='<%= p("cf.username") %>'
 CF_ADMIN_PASSWORD='<%= p("cf.password") %>'

--- a/manifests/operators/cf-admin-user.yml
+++ b/manifests/operators/cf-admin-user.yml
@@ -7,12 +7,11 @@
 - type: replace
   path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/consumes?/cf
   value:
-    from: cf
+    from: cf-admin-user
     deployment: cf
 
 - type: replace
   path: /instance_groups/name=broker-delete/jobs/name=broker-delete/consumes?/cf
   value:
-    from: cf
+    from: cf-admin-user
     deployment: cf
-

--- a/manifests/operators/cf-admin-user.yml
+++ b/manifests/operators/cf-admin-user.yml
@@ -5,13 +5,13 @@
   path: /instance_groups/name=broker-delete/jobs/name=broker-delete/properties/cf
 
 - type: replace
-  path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/consumes?/cf
+  path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/consumes?/cf-admin-user
   value:
     from: cf-admin-user
     deployment: cf
 
 - type: replace
-  path: /instance_groups/name=broker-delete/jobs/name=broker-delete/consumes?/cf
+  path: /instance_groups/name=broker-delete/jobs/name=broker-delete/consumes?/cf-admin-user
   value:
     from: cf-admin-user
     deployment: cf

--- a/manifests/operators/cf-app.yml
+++ b/manifests/operators/cf-app.yml
@@ -1,6 +1,6 @@
 ---
 - type: replace
-  path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/properties/cf/org?
+  path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/properties/cf?/org?
   value: ((cf-org))
 
 - type: replace
@@ -17,7 +17,7 @@
     - ((cf-route))
 
 - type: replace
-  path: /instance_groups/name=broker-delete/jobs/name=broker-delete/properties/cf/org?
+  path: /instance_groups/name=broker-delete/jobs/name=broker-delete/properties/cf?/org?
   value: ((cf-org))
 
 - type: replace

--- a/manifests/operators/cf-bonus-links.yml
+++ b/manifests/operators/cf-bonus-links.yml
@@ -2,4 +2,4 @@
   path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/properties/cf
 
 - type: remove
-  path: /instance_groups/name=broker-deploy/jobs/name=broker-delete/properties/cf
+  path: /instance_groups/name=broker-delete/jobs/name=broker-delete/properties/cf

--- a/manifests/operators/cf-bonus-links.yml
+++ b/manifests/operators/cf-bonus-links.yml
@@ -1,0 +1,5 @@
+- type: remove
+  path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/properties/cf
+
+- type: remove
+  path: /instance_groups/name=broker-deploy/jobs/name=broker-delete/properties/cf

--- a/manifests/operators/cf-bonus-links.yml
+++ b/manifests/operators/cf-bonus-links.yml
@@ -3,3 +3,16 @@
 
 - type: remove
   path: /instance_groups/name=broker-delete/jobs/name=broker-delete/properties/cf
+
+- type: replace
+  path: /instance_groups/name=broker-deploy/jobs/name=broker-deploy/consumes?/cf
+  value:
+    from: cf
+    deployment: cf
+
+- type: replace
+  path: /instance_groups/name=broker-delete/jobs/name=broker-delete/consumes?/cf
+  value:
+    from: cf
+    deployment: cf
+


### PR DESCRIPTION
An experiment with https://github.com/cloudfoundry-community/collection-of-pullrequests-boshrelease/tree/master/jobs/cf-admin-user to expose and share simple cf url/admin credentials from cf deployment to service brokers such as this one.